### PR TITLE
Using released maven dependencies and updated README.md accordignly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,32 @@ This is a work-in-progress implementation of the [Verifiable Credentials](https:
 Not ready for production use! Use at your own risk! Pull requests welcome.
 
 ### Maven
+First you need to add the following to to your "~/.m2/settings.xml". Here OWNER should be be developer's GitHub user name and TOKEN must be GitHub personal access token . For more information [follow](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) .
 
-First, you need to build the [ld-signatures-java](https://github.com/WebOfTrustInfo/ld-signatures-java) project.
+	<profiles>
+         <profile>
+           <id>github</id>
+           <repositories>
+	        <repository>
+              <id>github</id>
+              <name>GitHub WebOfTrustInfo ld-signatures-java</name>
+              <url>https://maven.pkg.github.com/WebOfTrustInfo/ld-signatures-java</url>
+            </repository>
+           </repositories>
+         </profile>
+    </profiles>
+	<servers>
+        <server>
+          <id>github</id>
+          <username> OWNER </username>
+          <password> TOKEN </password>
+        </server>
+      </servers>
 
-After that, just run:
-
-	mvn clean install
-
+To build the project
+~~~
+mvn install
+~~~
 Dependency:
 
 	<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,7 @@
 		<dependency>
 			<groupId>info.weboftrust</groupId>
 			<artifactId>ld-signatures-java</artifactId>
-			<version>0.2-SNAPSHOT</version>
-			<scope>compile</scope>
+			<version>0.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>


### PR DESCRIPTION
I have changes the ld-signature-java dependency from local to GitHub released plugin. And to use them, the developer need to modify  "~/.m2/settings.xm". The changes are added and required steps are added in README.md file.