### PR TITLE
Allow mutliple VCs in VP and validate VP without VC

### DIFF
--- a/src/main/java/com/danubetech/verifiablecredentials/VerifiablePresentation.java
+++ b/src/main/java/com/danubetech/verifiablecredentials/VerifiablePresentation.java
@@ -147,23 +147,45 @@ public class VerifiablePresentation extends JsonLDObject {
 	}
 
 	public VerifiableCredential getVerifiableCredential() {
-		Object verifiableCredentialObject = this.getJsonObject().get(VerifiableCredentialKeywords.JSONLD_TERM_VERIFIABLECREDENTIAL);
-		if ((verifiableCredentialObject instanceof List<?> && ! ((List<?>) verifiableCredentialObject).isEmpty() && ((List<?>) verifiableCredentialObject).get(0) instanceof Map)) {
-			return VerifiableCredential.getFromJsonLDObject(this);
-		} else if (verifiableCredentialObject instanceof Map) {
-			return VerifiableCredential.getFromJsonLDObject(this);
-		}
-		return null;
+		return getVerifiableCredentials().stream().findFirst().orElse(null);
 	}
 
 	public String getJwtVerifiableCredentialString() {
+		return getJwtVerifiableCredentialStrings().stream().findFirst().orElse(null);
+	}
+
+	private List<?> getVerifiableCredentialObjects() {
 		Object verifiableCredentialObject = this.getJsonObject().get(VerifiableCredentialKeywords.JSONLD_TERM_VERIFIABLECREDENTIAL);
-		if (verifiableCredentialObject instanceof List<?> && ! ((List<?>) verifiableCredentialObject).isEmpty() && ((List<?>) verifiableCredentialObject).get(0) instanceof String) {
-			return (String) ((List<?>) verifiableCredentialObject).get(0);
-		} else if (verifiableCredentialObject instanceof String) {
-			return (String) verifiableCredentialObject;
+		if (verifiableCredentialObject instanceof List<?>) {
+			return (List<?>) verifiableCredentialObject;
+		} else if (verifiableCredentialObject != null) {
+			return List.of(verifiableCredentialObject);
+		} else {
+			return List.of();
 		}
-		return null;
+	}
+
+	public List<VerifiableCredential> getVerifiableCredentials() {
+		List<?> vcObjs = getVerifiableCredentialObjects();
+		return vcObjs.stream()
+				.filter(o -> o instanceof Map)
+				.map(o -> VerifiableCredential.fromMap((Map) o))
+				.toList();
+	}
+
+	public List<String> getJwtVerifiableCredentialStrings() {
+		List<?> vcObjs = getVerifiableCredentialObjects();
+		return vcObjs.stream()
+				.filter(o -> o instanceof String)
+				.map(o -> (String) o)
+				.toList();
+	}
+
+	public List<?> getUnsupportedVerifiableCredentials() {
+		List<?> vcObjs = getVerifiableCredentialObjects();
+		return vcObjs.stream()
+				.filter(o -> ! (o instanceof Map || o instanceof String))
+				.toList();
 	}
 
 	public LdProof getLdProof() {

--- a/src/main/java/com/danubetech/verifiablecredentials/validation/Validation.java
+++ b/src/main/java/com/danubetech/verifiablecredentials/validation/Validation.java
@@ -68,6 +68,7 @@ public class Validation {
 
         validateRun(() -> validateTrue(! verifiablePresentation.getTypes().isEmpty()), "Bad or missing 'type'.");
         validateRun(() -> validateTrue(verifiablePresentation.getTypes().contains(VerifiablePresentation.DEFAULT_JSONLD_TYPES[0])), "type must contain VerifiablePresentation: " + verifiablePresentation.getTypes());
-        validateRun(() -> validateTrue(verifiablePresentation.getVerifiableCredential() != null || verifiablePresentation.getJwtVerifiableCredentialString() != null), "Bad or missing 'verifiableCredential'.");
+        validateRun(() -> validateTrue(verifiablePresentation.getUnsupportedVerifiableCredentials().isEmpty()), "Unsupported type in 'verifiableCredential'.");
+        validateRun(() -> validateTrue(verifiablePresentation.getVerifiableCredential() != null || verifiablePresentation.getJwtVerifiableCredentialString() != null), "Missing 'verifiableCredential'.");
     }
 }

--- a/src/main/java/com/danubetech/verifiablecredentials/validation/Validation.java
+++ b/src/main/java/com/danubetech/verifiablecredentials/validation/Validation.java
@@ -58,6 +58,11 @@ public class Validation {
 
     public static void validate(VerifiablePresentation verifiablePresentation) throws IllegalStateException {
 
+        validate(verifiablePresentation, true);
+    }
+
+    public static void validate(VerifiablePresentation verifiablePresentation, boolean requireVc) throws IllegalStateException {
+
         foundation.identity.jsonld.validation.Validation.validate(verifiablePresentation);
 
         validateRun(() -> validateTrue(verifiablePresentation.getJsonObject() != null), "Bad or missing JSON object.");
@@ -69,6 +74,8 @@ public class Validation {
         validateRun(() -> validateTrue(! verifiablePresentation.getTypes().isEmpty()), "Bad or missing 'type'.");
         validateRun(() -> validateTrue(verifiablePresentation.getTypes().contains(VerifiablePresentation.DEFAULT_JSONLD_TYPES[0])), "type must contain VerifiablePresentation: " + verifiablePresentation.getTypes());
         validateRun(() -> validateTrue(verifiablePresentation.getUnsupportedVerifiableCredentials().isEmpty()), "Unsupported type in 'verifiableCredential'.");
-        validateRun(() -> validateTrue(verifiablePresentation.getVerifiableCredential() != null || verifiablePresentation.getJwtVerifiableCredentialString() != null), "Missing 'verifiableCredential'.");
+        if (requireVc) {
+            validateRun(() -> validateTrue(verifiablePresentation.getVerifiableCredential() != null || verifiablePresentation.getJwtVerifiableCredentialString() != null), "Missing 'verifiableCredential'.");
+        }
     }
 }


### PR DESCRIPTION
The patches contain two changes.
1. A VP may contain multiple VCs, so the VerifiablePresentation class is modified to retrieve a list of VCs. A possible use multiple VCs is that a self signed VC containing user asserted data might be presented together with a VC asserted by a third party.
2. VPs might contain no VC. The Validation class enforces the presence of a VC, however OID4VCI uses ldp proofs to claim key ownership. Such a VP contains no VC. In order to retain backwards compatibility, a boolean flag in has been introduced in the validate method. 